### PR TITLE
Add missing imports to wmc tn module

### DIFF
--- a/src/tn/wmc_tn.py
+++ b/src/tn/wmc_tn.py
@@ -1,3 +1,6 @@
+import numpy as np
+from typing import List, Tuple
+
 def calculate_cut_value(adj_matrix: np.ndarray, partition: list[int]) -> int:
     """
     Calcula el valor del corte para una partición dada.


### PR DESCRIPTION
## Summary
- add numpy and typing imports to `src/tn/wmc_tn.py` so referenced types resolve

## Testing
- python -c "import src.tn.wmc_tn"


------
https://chatgpt.com/codex/tasks/task_e_68cd4f22e83483318a56acb208ef11ad